### PR TITLE
Fix stale command and RC candidates

### DIFF
--- a/lib/repo/repository.rb
+++ b/lib/repo/repository.rb
@@ -187,11 +187,11 @@ EOF
       re = /\A
         (?<name>.+)
         -
-        (?<version>[0-9][.0-9]*(~[^-]+)?)
+        (?<version>[^-]+)
         -
-        (?<release>.*)
+        (?<release>[^-]+)
         \.
-        (?<arch>[-_a-z0-9]+)
+        (?<arch>[^.]+)
         \.rpm
       \Z/x
       names.sort_by do |name|

--- a/lib/repo/repository.rb
+++ b/lib/repo/repository.rb
@@ -174,7 +174,7 @@ EOF
       names = Dir.glob(File.join(wd, "*#{Config.extname}")).map(&File.method(:basename))
       if Config.extname == '.rpm'
         # The dev RPM repos might contain release candidates.  Sorting them
-        # correctly is much more complicated.  The complicated sorting method
+        # correctly is more complicated.  The complicated sorting method
         # is limited to RPM repos to avoid having to write a version that
         # works correctly for .deb files.
         semantic_version_sort(names)
@@ -183,7 +183,12 @@ EOF
       end
     end
 
+    # Sort RPM names such that obeys RC releases, e.g., `1.0.0~rc1-1` appears
+    # before `1.0.0-1`.
     def semantic_version_sort(names)
+      # This could be done by run `rpm -qp --queryformat
+      # '%{Name}\n%{Version}\n%{Release}` <package>`, but that is *much*
+      # slower than a regex.
       re = /\A
         (?<name>.+)
         -


### PR DESCRIPTION
Fixes #1 for RPMs.   A similar fix for `.deb` files should be simple, but it hasn't been implemented.