### PR TITLE
Add `run-release` command to build, publish and promote multiple packages

### DIFF
--- a/lib/repo/cli.rb
+++ b/lib/repo/cli.rb
@@ -139,13 +139,25 @@ EOF
     end
 
     command :'run-release' do |c|
-      cli_syntax(c, 'FILE')
-      c.summary = 'Build, publish and promote the packages given by FILE'
+      cli_syntax(c, 'FILE [--build|--publish|--promote]')
+      c.summary = 'Build, publish and/or promote the packages given in FILE'
       c.action Commands, :run_release
       c.description = <<EOF
 Build, publish and promote the packages given by FILE
+
+FILE is expected to be a YAML file containing a list of package names, build
+type and expected version.  E.g.,
+
+```
+- name: flight-desktop
+  version: 1.7.0-1
+  build_type: omnibus
+- name: flight-desktop-types
+  version: 1.1.0-1
+  build_type: build.sh
+```
 EOF
-      c.option '--build', 'Build the packages'
+      c.option '--build', 'Build the specified packages'
       c.option '--publish', 'Publish packages to dev repos'
       c.option '--promote', 'Promote packages to production repos'
     end

--- a/lib/repo/cli.rb
+++ b/lib/repo/cli.rb
@@ -137,5 +137,14 @@ EOF
       c.option '--any', 'Show any stale packages, not just minor release multiples'
       c.option '--terse', 'Suppress everything but package names'
     end
+
+    command :'run-release' do |c|
+      cli_syntax(c, 'FILE')
+      c.summary = 'Build, publish and promote the packages given by FILE'
+      c.action Commands, :run_release
+      c.description = <<EOF
+Build, publish and promote the packages given by FILE
+EOF
+    end
   end
 end

--- a/lib/repo/cli.rb
+++ b/lib/repo/cli.rb
@@ -145,7 +145,6 @@ EOF
       c.description = <<EOF
 Build, publish and promote the packages given by FILE
 EOF
-      c.option '--build-deps', 'Install build dependencies required by the packages'
       c.option '--build', 'Build the packages'
       c.option '--publish', 'Publish packages to dev repos'
       c.option '--promote', 'Promote packages to production repos'

--- a/lib/repo/cli.rb
+++ b/lib/repo/cli.rb
@@ -145,6 +145,7 @@ EOF
       c.description = <<EOF
 Build, publish and promote the packages given by FILE
 EOF
+      c.option '--build-deps', 'Install build dependencies required by the packages'
       c.option '--build', 'Build the packages'
       c.option '--publish', 'Publish packages to dev repos'
       c.option '--promote', 'Promote packages to production repos'

--- a/lib/repo/cli.rb
+++ b/lib/repo/cli.rb
@@ -145,6 +145,9 @@ EOF
       c.description = <<EOF
 Build, publish and promote the packages given by FILE
 EOF
+      c.option '--build', 'Build the packages'
+      c.option '--publish', 'Publish packages to dev repos'
+      c.option '--promote', 'Promote packages to production repos'
     end
   end
 end

--- a/lib/repo/commands.rb
+++ b/lib/repo/commands.rb
@@ -29,6 +29,7 @@ require_relative 'commands/list'
 require_relative 'commands/promote'
 require_relative 'commands/publish'
 require_relative 'commands/reindex'
+require_relative 'commands/run_release'
 require_relative 'commands/stale'
 require_relative 'commands/vault'
 

--- a/lib/repo/commands/run_release.rb
+++ b/lib/repo/commands/run_release.rb
@@ -1,0 +1,157 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of OpenFlight Omnibus Builder.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# OpenFlight Omnibus Builder is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with OpenFlight Omnibus Builder. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on OpenFlight Omnibus Builder, please visit:
+# https://github.com/openflighthpc/openflight-omnibus-builder
+#==============================================================================
+require_relative '../command'
+require_relative '../repository'
+require_relative '../arch'
+require_relative '../slack'
+
+require 'yaml'
+require 'open3'
+
+module Repo
+  module Commands
+    class RunRelease < Command
+      def run
+        if !Slack.auth?
+          raise RepoError, "Valid Slack token not found; configure SLACK_TOKEN environment variable"
+        end
+
+        packages.each do |package|
+          remove_artefacts(package)
+          clean(package)
+          build(package)
+          # publish(package)
+        end
+        packages.each do |package|
+          # promote(package)
+        end
+      end
+
+      private
+
+      def packages
+        if File.exist?(args[0])
+          YAML.load_file(args[0])
+        else
+          raise RuntimeError, "file #{args[0]} not found"
+        end
+      end
+
+      def remove_artefacts(package)
+        # XXX Remove *el7* hardcoding.
+        header "Removing build artefacts #{package['name']}"
+        Dir.chdir("/vagrant/builders/#{package['name']}") do
+          cmd = ["rm", "-rf", "pkg/*el7*"]
+          out, status = Open3.capture2(*cmd)
+          puts out
+          unless status.success?
+            raise RuntimeError, "Failed to remove artefacts #{package['name']}"
+          end
+        end
+      end
+
+      def clean(package)
+        return if package['type'] == 'build.sh'
+
+        header "Cleaning package #{package['name']}"
+        Dir.chdir("/vagrant/builders/#{package['name']}") do
+          cmd = ["./bin/omnibus", "clean", package['name']]
+          out, status = Open3.capture2(*cmd)
+          puts out
+          unless status.success?
+            raise RuntimeError, "Failed to clean #{package['name']}"
+          end
+        end
+      end
+
+      def build(package)
+        header "Building package #{package['name']}"
+        Dir.chdir("/vagrant/builders/#{package['name']}") do
+          cmd =
+            if package['type'] == 'build.sh'
+              ["./build.sh"]
+            else
+              ["./bin/omnibus", "build", package['name']]
+            end
+          out, status = Open3.capture2(*cmd)
+          puts out
+          unless status.success?
+            raise RuntimeError, "Failed to build #{package['name']}"
+          end
+          # XXX Remove *el7* hardcoding.
+          built =
+            if package['noarch']
+              Dir.glob("pkg/#{package['name']}?#{package['version']}*.noarch.*rpm")
+            else
+              Dir.glob("pkg/#{package['name']}?#{package['version']}*.el7.*rpm")
+            end
+          if built.empty?
+            raise RuntimeError, "Failed to build expected version #{package['name']} #{package['version']}. Found #{built.join(' ')}"
+          end
+        end
+      end
+
+      def publish(package)
+        # XXX Remove *el7* hardcoding.
+        # XXX Remove *x86_64* hardcoding.
+        Dir.chdir("/vagrant/builders/#{package['name']}") do
+          Dir.glob("pkg/flight-*.el7.x86_64.rpm").each do |p|
+            cmd = ["/vagrant/scripts/repo", "publish", "-a", "x86_64", p]
+            out, status = Open3.capture2(*cmd)
+            puts out
+            unless status.success?
+              raise RuntimeError, "Failed to publish #{package['name']}"
+            end
+          end
+        end
+      end
+
+      def promote(package)
+        # XXX Remove *el7* hardcoding.
+        # XXX Remove *x86_64* hardcoding.
+        Dir.chdir("/vagrant/builders/#{package['name']}") do
+          Dir.glob("pkg/flight-*.el7.x86_64.rpm").each do |p|
+            cmd = ["/vagrant/scripts/repo", "promote", "-a", "x86_64", p]
+            out, status = Open3.capture2(*cmd)
+            puts out
+            unless status.success?
+              raise RuntimeError, "Failed to promote #{package['name']}"
+            end
+          end
+        end
+      end
+
+      def header(text)
+        puts
+        puts("=" * text.length)
+        puts text
+        puts("=" * text.length)
+        puts
+      end
+    end
+  end
+end

--- a/lib/repo/commands/run_release.rb
+++ b/lib/repo/commands/run_release.rb
@@ -276,7 +276,10 @@ module Repo
 
       def logger
         return @logger if @logger
-        file = File.open('/vagrant/run_release_built_packages.log', File::WRONLY | File::APPEND | File::CREAT)
+        file = File.open(
+          "/vagrant/run_release.#{Config.distro}.log",
+          File::WRONLY | File::APPEND | File::CREAT
+        )
         @logger = Logger.new(file, level: 'INFO')
       end
     end

--- a/lib/repo/commands/run_release.rb
+++ b/lib/repo/commands/run_release.rb
@@ -121,7 +121,6 @@ module Repo
         packages.each do |package|
           if options.build && !package.built && !package.skip
             remove_artefacts(package)
-            install_deps(package) if options.build_deps
             clean(package)
             build(package)
           end
@@ -153,20 +152,6 @@ module Repo
         package.build_artefacts.each do |p|
           unless FileUtils.rm_f(p, verbose: true)
             raise RepoError, "Failed to remove artefacts #{package.name}"
-          end
-        end
-      end
-
-      def install_deps(package)
-        return unless package.build_type == 'omnibus'
-
-        header "Installing build dependencies package #{package.name}"
-        Dir.chdir(package.dir) do
-          cmd = ["bundle", "install"]
-          out, status = Open3.capture2(*cmd)
-          puts out
-          unless status.success?
-            raise RepoError, "Failed to install build deps #{package.name}"
           end
         end
       end

--- a/lib/repo/commands/run_release.rb
+++ b/lib/repo/commands/run_release.rb
@@ -1,5 +1,5 @@
 #==============================================================================
-# Copyright (C) 2020-present Alces Flight Ltd.
+# Copyright (C) 2021-present Alces Flight Ltd.
 #
 # This file is part of OpenFlight Omnibus Builder.
 #
@@ -64,7 +64,7 @@ module Repo
         end
 
         def dir
-          "/vagrant/builders/#{name}"
+          File.join(Config.source_package_root, name)
         end
 
         def serializable_hash
@@ -213,7 +213,7 @@ module Repo
         end
 
         artefacts = packages.map(&:build_artefacts).flatten
-        cmd = ["/vagrant/scripts/repo", "publish", "-a", arch.name] + artefacts
+        cmd = [Config.repo_command, "publish", "-a", arch.name] + artefacts
         out, status = Open3.capture2(*cmd)
         puts out
         unless status.success?
@@ -233,7 +233,7 @@ module Repo
         end
 
         built_packages = packages.map(&:built_package_names).flatten
-        cmd = ["/vagrant/scripts/repo", "promote", "-a", arch.name] + built_packages
+        cmd = [Config.repo_command, "promote", "-a", arch.name] + built_packages
         out, status = Open3.capture2(*cmd)
         puts out
         unless status.success?

--- a/lib/repo/commands/run_release.rb
+++ b/lib/repo/commands/run_release.rb
@@ -176,6 +176,7 @@ module Repo
       end
 
       def build(package)
+        logger.info("Building #{package.name} (#{package.version})")
         header "Building package #{package.name}"
         Dir.chdir(package.dir) do
           cmd =
@@ -212,6 +213,7 @@ module Repo
       end
 
       def publish(package)
+        logger.info("Publishing #{package.name} (#{package.version})")
         package.build_artefacts.each do |p|
           cmd = ["/vagrant/scripts/repo", "publish", "-a", arch, p]
           out, status = Open3.capture2(*cmd)
@@ -225,6 +227,7 @@ module Repo
       end
 
       def promote(package)
+        logger.info("Promoting #{package.name} (#{package.version})")
         package.built_package_names.each do |p|
           cmd = ["/vagrant/scripts/repo", "promote", "-a", arch, p]
           out, status = Open3.capture2(*cmd)

--- a/lib/repo/commands/run_release.rb
+++ b/lib/repo/commands/run_release.rb
@@ -35,6 +35,68 @@ require 'open3'
 module Repo
   module Commands
     class RunRelease < Command
+
+      # The package that is being built.
+      class TargetPackage
+        attr_reader :name, :version, :build_type
+
+        def initialize(hash, arch)
+          @name = hash['name']
+          @version = hash['version']
+          @build_type = hash['build_type'] || 'omnibus'
+          @arch = arch
+        end
+
+        # Paths to the built package files to publish.
+        def build_artefacts
+          Dir.glob("#{dir}/pkg/flight-*#{version}#{distro_glob}") + noarch_packages
+        end
+
+        # The names of the built packages.  Used to promote.
+        def built_package_names
+          build_artefacts.map { |p| File.basename(p) }
+        end
+
+        def dir
+          "/vagrant/builders/#{name}"
+        end
+
+        private
+
+        def noarch_packages
+          return [] if Config.distro == 'ubuntu'
+
+          exclude =
+            case Config.distro
+            when 'centos/7'
+              /\.el8\./
+            when 'centos/8'
+              /\.el7\./
+            end
+
+          Dir.glob("#{dir}/pkg/flight-*#{version}*noarch*.rpm").select do |p|
+            name = File.basename(p)
+            !name.match(exclude)
+          end
+        end
+
+        # A glob that matches the built RPMs or Debs for this package.
+        def distro_glob
+          case Config.distro
+          when 'centos/7'
+            # XXX match '*noarch.rpm' too.
+            "*.el7.#{@arch.name}.rpm"
+          when 'centos/8'
+            # XXX match '*noarch.rpm' too.
+            "*.el8.#{@arch.name}.rpm"
+          when 'ubuntu'
+            '*.deb'
+          else
+            raise RepoError, "unknown distro #{Config.distro}"
+          end
+        end
+      end
+
       def run
         if !Slack.auth?
           raise RepoError, "Valid Slack token not found; configure SLACK_TOKEN environment variable"
@@ -42,13 +104,20 @@ module Repo
         assert_arch
 
         packages.each do |package|
-          remove_artefacts(package)
-          clean(package)
-          build(package)
-          # publish(package)
+          if options.build
+            remove_artefacts(package)
+            clean(package)
+            build(package)
+          end
+          if options.publish
+            publish(package)
+          end
         end
-        packages.each do |package|
-          # promote(package)
+
+        if options.promote
+          packages.each do |package|
+            promote(package)
+          end
         end
       end
 
@@ -56,81 +125,87 @@ module Repo
 
       def packages
         if File.exist?(args[0])
-          YAML.load_file(args[0])
+          YAML.load_file(args[0]).map { |p| TargetPackage.new(p, arch) }
         else
           raise RepoError, "file #{args[0]} not found"
         end
       end
 
       def remove_artefacts(package)
-        header "Removing build artefacts #{package['name']}"
-        Dir.chdir("/vagrant/builders/#{package['name']}") do
-          cmd = ["rm", "-rf", "pkg/#{pkg_glob}*"]
-          out, status = Open3.capture2(*cmd)
-          puts out
-          unless status.success?
-            raise RepoError, "Failed to remove artefacts #{package['name']}"
+        header "Removing build artefacts #{package.name}"
+        package.build_artefacts.each do |p|
+          unless FileUtils.rm_f(p, verbose: true)
+            raise RepoError, "Failed to remove artefacts #{package.name}"
           end
         end
       end
 
       def clean(package)
-        return if package['type'] == 'build.sh'
+        return unless package.build_type == 'omnibus'
 
-        header "Cleaning package #{package['name']}"
-        Dir.chdir("/vagrant/builders/#{package['name']}") do
-          cmd = ["./bin/omnibus", "clean", "--purge", package['name']]
+        header "Cleaning package #{package.name}"
+        Dir.chdir(package.dir) do
+          cmd = ["./bin/omnibus", "clean", "--purge", package.name]
           out, status = Open3.capture2(*cmd)
           puts out
           unless status.success?
-            raise RepoError, "Failed to clean #{package['name']}"
+            raise RepoError, "Failed to clean #{package.name}"
           end
         end
       end
 
       def build(package)
-        header "Building package #{package['name']}"
-        Dir.chdir("/vagrant/builders/#{package['name']}") do
+        header "Building package #{package.name}"
+        Dir.chdir(package.dir) do
           cmd =
-            if package['type'] == 'build.sh'
+            case package.build_type
+            when 'build.sh'
               ["./build.sh"]
+            when 'omnibus'
+              ["./bin/omnibus", "build", package.name]
             else
-              ["./bin/omnibus", "build", package['name']]
+              raise RepoError, "unknown build type #{package.build_type}"
             end
+
           out, status = Open3.capture2(*cmd)
           puts out
           unless status.success?
-            raise RepoError, "Failed to build #{package['name']}"
+            raise RepoError, "Failed to build #{package.name}"
           end
-          built = Dir.glob("pkg/#{package['name']}?#{package['version']}#{pkg_glob}")
-          if built.empty?
-            raise RepoError, "Failed to build expected version #{package['name']} #{package['version']}. Found #{built.join(' ')}"
+
+          found_expected = package.built_package_names.any? do |p|
+            p.match(/#{package.name}[-_]#{package.version}/)
           end
+          unless found_expected
+            raise RepoError, "Failed to build expected version #{package.name}-#{package.version}. Found #{package.built_package_names.join(' ')}"
+          end
+
+          subheader "Built the following"
+          package.built_package_names.each do |p|
+            puts "  #{p}"
+          end
+          puts
         end
       end
 
       def publish(package)
-        Dir.chdir("/vagrant/builders/#{package['name']}") do
-          Dir.glob("pkg/flight-#{pkg_glob}").each do |p|
-            cmd = ["/vagrant/scripts/repo", "publish", "-a", arch, p]
-            out, status = Open3.capture2(*cmd)
-            puts out
-            unless status.success?
-              raise RepoError, "Failed to publish #{package['name']}"
-            end
+        package.build_artefacts.each do |p|
+          cmd = ["/vagrant/scripts/repo", "publish", "-a", arch, p]
+          out, status = Open3.capture2(*cmd)
+          puts out
+          unless status.success?
+            raise RepoError, "Failed to publish #{package.name}"
           end
         end
       end
 
       def promote(package)
-        Dir.chdir("/vagrant/builders/#{package['name']}") do
-          Dir.glob("pkg/flight-#{pkg_glob}").each do |p|
-            cmd = ["/vagrant/scripts/repo", "promote", "-a", arch, p]
-            out, status = Open3.capture2(*cmd)
-            puts out
-            unless status.success?
-              raise RepoError, "Failed to promote #{package['name']}"
-            end
+        package.built_package_names.each do |p|
+          cmd = ["/vagrant/scripts/repo", "promote", "-a", arch, p]
+          out, status = Open3.capture2(*cmd)
+          puts out
+          unless status.success?
+            raise RepoError, "Failed to promote #{package.name}"
           end
         end
       end
@@ -143,17 +218,11 @@ module Repo
         puts
       end
 
-      def pkg_glob
-        case Config.distro
-        when 'centos/7'
-          '*.el7.*rpm'
-        when 'centos/8'
-          '*.el8.*rpm'
-        when 'ubuntu'
-          '*.deb'
-        else
-          raise RepoError, "unknown distro #{Config.distro}"
-        end
+      def subheader(text)
+        puts
+        puts text
+        puts("-" * text.length)
+        puts
       end
 
       def arch

--- a/lib/repo/commands/run_release.rb
+++ b/lib/repo/commands/run_release.rb
@@ -31,6 +31,7 @@ require_relative '../slack'
 
 require 'yaml'
 require 'open3'
+require 'logger'
 
 module Repo
   module Commands
@@ -119,6 +120,8 @@ module Repo
             promote(package)
           end
         end
+      ensure
+        logger.close
       end
 
       private
@@ -183,6 +186,7 @@ module Repo
           subheader "Built the following"
           package.built_package_names.each do |p|
             puts "  #{p}"
+            logger.info("Built #{p}")
           end
           puts
         end
@@ -196,6 +200,7 @@ module Repo
           unless status.success?
             raise RepoError, "Failed to publish #{package.name}"
           end
+          logger.info("Published #{p}")
         end
       end
 
@@ -207,6 +212,7 @@ module Repo
           unless status.success?
             raise RepoError, "Failed to promote #{package.name}"
           end
+          logger.info("Promoted #{p}")
         end
       end
 
@@ -236,6 +242,12 @@ module Repo
           end
       end
       alias_method :assert_arch, :arch
+
+      def logger
+        return @logger if @logger
+        file = File.open('/vagrant/run_release_built_packages.log', File::WRONLY | File::APPEND | File::CREAT)
+        @logger = Logger.new(file, level: 'INFO')
+      end
     end
   end
 end

--- a/lib/repo/config.rb
+++ b/lib/repo/config.rb
@@ -151,6 +151,22 @@ module Repo
             default: 'OpenFlight'
           )
       end
+
+      def source_package_root
+        @source_package_root ||=
+          data.fetch(
+            'source_package_root',
+            default: '/vagrant/builders'
+          )
+      end
+
+      def repo_command
+        @repo_command ||=
+          data.fetch(
+            'repo_command',
+            default: '/vagrant/scripts/repo'
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
Creating a new release for Flight User Suite and Flight Web Suite involves building and publishing multiple packages across multiple distros.  Often times, parts of this can fail. For instance, a package might not build, or it might still be configured build an `~rc*` candidate, or it might build with an old version of a generated file, or it might fail to publish or promote.

This PR adds a new command, `run-release`, which addresses these issues.  It is called like this:

```
repo run-release [--build|--publish|--promote] <path/to/release.yaml>
```

It will build, publish and/or promote the packages given in `release.yaml`.  In doing so it has the following behaviour.

* Removes old build artefacts.
* Ensures each build is `clean --purge`d first.
* Ensures that the expected version has been built.
* Maintains a record of its progress, enabling it to pick up where it left
  off.
* Aborts as soon as an error occurs.
* Logs its progress.

The YAML file that it builds from looks like this:

```
---
- name: flight-desktop
  version: 1.7.0-1
  build_type: omnibus
  built:
  published:
  promoted:
- name: flight-desktop-types
  version: 1.1.0-1
  build_type: build.sh
  built:
  published:
  promoted:
```

* `name:` the name of the package to build.
* `version:` the version that is expected to be built.  If this version is not built, an error will be raised.
* `build_type`: whether the build is performed by calling `./build.sh` or by using `omnibus`.
